### PR TITLE
Remove unneeded network files from util load

### DIFF
--- a/network/utils.py
+++ b/network/utils.py
@@ -35,10 +35,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from network.mynn import Norm2d, Upsample
-from network.xception import xception71
-from network.wider_resnet import wrn38
 from network.SEresnext import se_resnext50_32x4d, se_resnext101_32x4d
-from network.Resnet import resnet50, resnet101
 import network.hrnetv2 as hrnetv2
 
 from runx.logx import logx


### PR DESCRIPTION
After https://github.com/VIDA-NYU/city-surfaces/commit/da210df3ba2ce2ee3fd986bdbdacb93b157c314d, these files need removing from `util` load